### PR TITLE
Port to 4.13.2

### DIFF
--- a/OSC/Source/OSC/Private/Common/OscDataElemStruct.h
+++ b/OSC/Source/OSC/Private/Common/OscDataElemStruct.h
@@ -112,7 +112,7 @@ public:
     {
         Data = 0;
         Type = BLOB;
-        Blob = MakeShared<TArray<uint8>>(std::move(value));
+        Blob = MakeShareable(&value);
     }
 
     const TArray<uint8> & AsBlobValue() const


### PR DESCRIPTION
There were compile errors when I was trying to build the plugin with version 4.13.2 of the engine. This should fix the compile error. Didn't test it on latest version(4.14.1) tho but I think it should compile just fine.