### PR TITLE
On Win32, change strcpy to strcpy_s and use strncpy elsewhere

### DIFF
--- a/OSC/Source/OSC/Private/Common/oscpack/osc/OscOutboundPacketStream.cpp
+++ b/OSC/Source/OSC/Private/Common/oscpack/osc/OscOutboundPacketStream.cpp
@@ -356,8 +356,12 @@ OutboundPacketStream& OutboundPacketStream::operator<<( const BeginMessage& rhs 
     {
         messageCursor_ = BeginElement( messageCursor_ );
 
-        std::strcpy( messageCursor_, rhs.addressPattern );
-        std::size_t rhsLength = std::strlen(rhs.addressPattern);
+        std::size_t rhsLength = std::strlen( rhs.addressPattern );
+#if defined(__WIN32__) || defined(WIN32) || defined(_WIN32)
+        strcpy_s( messageCursor_, rhsLength, rhs.addressPattern );
+#else
+        std::strncpy( messageCursor_, rhs.addressPattern, rhsLength );
+#endif
         messageCursor_ += rhsLength + 1;
 
         // zero pad to 4-byte boundary
@@ -634,8 +638,12 @@ OutboundPacketStream& OutboundPacketStream::operator<<( const char *rhs )
     if(state_ == SUCCESS)
     {
         *(--typeTagsCurrent_) = STRING_TYPE_TAG;
-        std::strcpy( argumentCurrent_, rhs );
-        std::size_t rhsLength = std::strlen(rhs);
+        std::size_t rhsLength = std::strlen( rhs );
+#if defined(__WIN32__) || defined(WIN32) || defined(_WIN32)
+        strcpy_s( argumentCurrent_, rhsLength, rhs );
+#else
+        std::strncpy( argumentCurrent_, rhs, rhsLength );
+#endif
         argumentCurrent_ += rhsLength + 1;
 
         // zero pad to 4-byte boundary
@@ -657,8 +665,12 @@ OutboundPacketStream& OutboundPacketStream::operator<<( const Symbol& rhs )
     if(state_ == SUCCESS)
     {
         *(--typeTagsCurrent_) = SYMBOL_TYPE_TAG;
-        std::strcpy( argumentCurrent_, rhs );
-        std::size_t rhsLength = std::strlen(rhs);
+        std::size_t rhsLength = std::strlen( rhs );
+#if defined(__WIN32__) || defined(WIN32) || defined(_WIN32)
+        strcpy_s( argumentCurrent_, rhsLength, rhs );
+#else
+        std::strncpy( argumentCurrent_, rhs, rhsLength );
+#endif
         argumentCurrent_ += rhsLength + 1;
 
         // zero pad to 4-byte boundary

--- a/OSC/Source/OSC/Private/Receive/OscReceiverInputKey.cpp
+++ b/OSC/Source/OSC/Private/Receive/OscReceiverInputKey.cpp
@@ -10,7 +10,7 @@ OscReceiverInputKey::OscReceiverInputKey(const FString &address)
     _addressName(*address)
 {
     char buffer[512];  // address truncated after 500 chars.
-    const auto length = sprintf(buffer, "OSC%.500s", StringCast<ANSICHAR>(*address).Get());
+    const auto length = snprintf(buffer, 512, "OSC%.500s", StringCast<ANSICHAR>(*address).Get());
 
     // replace '/' by '_' because '/' is not a valid FKey character.
     for(int i=0; i!=length; ++i)


### PR DESCRIPTION
This PR was mainly to get rid of a number of warnings when compiling on Windows. It also uses shifts other architectures over to use strncpy rather than strcpy.

I haven't been able to test this on any OS other than Windows(VS2017), as I don't have a UE4 development environment on anything else.