### PR TITLE
Add method to OscFunctionLibrary to remove sendTargets

### DIFF
--- a/OSC/Source/OSC/Private/OscSettings.cpp
+++ b/OSC/Source/OSC/Private/OscSettings.cpp
@@ -74,6 +74,44 @@ int32 UOscSettings::AddSendTarget(const FString & ip_port)
     return result;
 }
 
+bool UOscSettings::RemoveSendOscTarget(int32 targetIndex)
+{
+    if(_sendAddresses.Num() == 0)
+    {
+        return false;
+    }
+
+    if(targetIndex == -1)
+    {
+        _sendAddressesIndex.Empty();
+        _sendAddresses.Empty();
+        return true;
+    }
+    else if(targetIndex < _sendAddresses.Num())
+    {
+        _sendAddresses.RemoveAt( targetIndex );
+
+        for(auto &sendAddressIndex : _sendAddressesIndex)
+        {
+            if(sendAddressIndex.Value == targetIndex)
+            {
+                _sendAddressesIndex.Remove(sendAddressIndex.Key);
+            }
+            else if(sendAddressIndex.Value > targetIndex)
+            {
+                // As we have removed a value from the _sendAddresses array,
+                // we need to decrement all subsequent values to ensure that
+                // they still line up.
+                sendAddressIndex.Value -= 1;
+            }
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
 static bool SendImpl(FSocket *socket, const uint8 *buffer, int32 length, const FInternetAddr & target)
 {
     int32 bytesSent = 0;

--- a/OSC/Source/OSC/Private/OscSettings.h
+++ b/OSC/Source/OSC/Private/OscSettings.h
@@ -61,6 +61,8 @@ public:
 
     int32 GetOrAddSendTarget(const FString & ip_port);
 
+    bool RemoveSendOscTarget(int32 targetIndex);
+
     void Send(const uint8 *buffer, int32 length, int32 targetIndex);
 
     void ClearKeyInputs(UOscDispatcher & dispatcher);

--- a/OSC/Source/OSC/Public/Common/OscFunctionLibrary.cpp
+++ b/OSC/Source/OSC/Public/Common/OscFunctionLibrary.cpp
@@ -319,3 +319,8 @@ int32 UOscFunctionLibrary::AddSendOscTarget(FString IpPort)
 {
     return GetMutableDefault<UOscSettings>()->GetOrAddSendTarget(IpPort);
 }
+
+bool UOscFunctionLibrary::RemoveSendOscTarget(int32 TargetIndex)
+{
+    return GetMutableDefault<UOscSettings>()->RemoveSendOscTarget(TargetIndex);
+}

--- a/OSC/Source/OSC/Public/Common/OscFunctionLibrary.h
+++ b/OSC/Source/OSC/Public/Common/OscFunctionLibrary.h
@@ -125,4 +125,17 @@ public:
      */
     UFUNCTION(BlueprintCallable, Category=OSC)
     static int32 AddSendOscTarget(FString IpPort = "127.0.0.1:8000");
+
+    /**
+     *  @brief Remove the specified target from the available OSC send targets.
+     *  @param TargetIndex index of the target to remove, -1 for all targets.
+     *  @return Whether any targets were removed.
+     *
+     *  Use this function to remove targets at runtime. Generally, it is best
+     *  to define your targets in the OSC plugin settings.
+     *
+     *  @see SendOsc
+     */
+    UFUNCTION(BlueprintCallable, Category=OSC)
+    static bool RemoveSendOscTarget(int32 TargetIndex);
 };


### PR DESCRIPTION
This PR adds a method to OscFunctionLibrary (and OscSettings) to remove one or all of the sendTargets at runtime.

I'm wanting to use this in my own code to allow my OSC device to send a "Sync" message, and have UE4-OSC automatically set up its own sendTarget. If the device disconnects, or is swapped out with another, I want to be able to remove the existing sendTargets before registering a new one.